### PR TITLE
MOIA-55452: Also retry stack status fails

### DIFF
--- a/cloudformation_test.go
+++ b/cloudformation_test.go
@@ -338,7 +338,7 @@ func Test_waitForNext(t *testing.T) {
 	}
 
 	waitFor = time.Second * 50
-	if waitForNext(waitFor) != maxWaitInterval {
+	if waitForNext(waitFor) != maxRetryInterval {
 		t.Fail()
 	}
 }


### PR DESCRIPTION
It makes sense to also retry when describing the stack fails. Since we
have a lot of time and we backoff exponentially this also shouldn't
contribute to overloading the API even more.

It probably also makes sense to immediately wait a little more aggressively
in order to take pressure off the CloudFormation API.