### PR TITLE
Threadsafe retries (2nd attempt)

### DIFF
--- a/cloudformation.go
+++ b/cloudformation.go
@@ -134,8 +134,8 @@ func (c *Cloudformation) executeChangeSet(changeSetName string) error {
 
 			return nil
 		case cloudformation.StackStatusCreateInProgress, cloudformation.StackStatusUpdateInProgress:
-			c.logger().Infof("Encountered an error and will retry. Will stop making more attempts to deploy after %s. Reason for retrying was: %s",
-				endRetryTimestamp.Format(time.RFC3339), err)
+			c.logger().Infof("Stack update still in progress. Will check again. Will stop making more attempts to deploy after %s.",
+				endRetryTimestamp.Format(time.RFC3339))
 
 			return fmt.Errorf("stack creation not complete yet, status: %s", stackStatus)
 		}

--- a/cloudformation.go
+++ b/cloudformation.go
@@ -127,7 +127,8 @@ func (c *Cloudformation) executeChangeSet(changeSetName string) error {
 			return nil
 		}
 
-		switch *dso.Stacks[0].StackStatus {
+		stackStatus := *dso.Stacks[0].StackStatus
+		switch stackStatus {
 		case cloudformation.StackStatusUpdateComplete, cloudformation.StackStatusCreateComplete, cloudformation.StackStatusUpdateCompleteCleanupInProgress:
 			c.logger().Infof("ChangeSet '%s' has been successfully executed.", changeSetName)
 
@@ -136,10 +137,10 @@ func (c *Cloudformation) executeChangeSet(changeSetName string) error {
 			c.logger().Infof("Encountered an error and will retry. Will stop making more attempts to deploy after %s. Reason for retrying was: %s",
 				endRetryTimestamp.Format(time.RFC3339), err)
 
-			return err
+			return fmt.Errorf("stack creation not complete yet, status: %s", stackStatus)
 		}
 
-		errToReturn = fmt.Errorf("unexpected stack status for stack %s: %s", *dso.Stacks[0].StackName, *dso.Stacks[0].StackStatus)
+		errToReturn = fmt.Errorf("unexpected stack status for stack %s: %s", *dso.Stacks[0].StackName, stackStatus)
 
 		return nil
 	}, back)


### PR DESCRIPTION
This builds on top of #10 , making the retry logic thread-safe.

However, we didn't correctly handle the state of stacks still being in progress.
In this case, we want to retry - the library needs a non-nil error to trigger a retry.

We incorrectly returned an error variable which was nil. Now, we return a non-nil error, so that retries should happen as expected.